### PR TITLE
handle credential secret deletion more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Attempt to ensure credentials secret isn't deleted until the cleaner has finished consuming it.
+
 ## [0.3.1] - 2024-08-01
 
 ### Changed

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,6 +11,8 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:


### PR DESCRIPTION
this PR attempts to block deletion of the `clustername-credentials` secret until it the cleaner has finished consuming it. This is necessary because if the secret is deleted too early then the cleaner will fail to remove the finalizer from the vspherecluster which will block its deletion indefinitely.

## Checklist

- [x] Update changelog in CHANGELOG.md.
