### PR TITLE
chore: standardize vSphere app icon on light variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update golang base docker image to v1.26.
+- Update vSphere app icon to the light variant (`https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png`).
 
 ### Fixed
 

--- a/helm/cluster-api-cleaner-vsphere/Chart.yaml
+++ b/helm/cluster-api-cleaner-vsphere/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.5.1
 appVersion: 0.5.1
 description: "Operator for cleaning leftover Vsphere resources of workload clusters"
 home: "https://github.com/giantswarm/cluster-api-cleaner-vsphere"
-icon: https://s.giantswarm.io/app-icons/vsphere/2/icon-dark.png
+icon: https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png
 annotations:
   io.giantswarm.application.team: "rocket"
   config.giantswarm.io/version: 1.x.x


### PR DESCRIPTION
Standardizes the vSphere app icon on the **light** variant, matching the other vSphere charts (`cluster-vsphere`, `cloud-provider-vsphere-app`, `cluster-nutanix`):

`https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png`

This chart was still on `icon-dark.png`. Only the `icon:` field is changed; the `ui.giantswarm.io/logo` annotation is intentionally left on the dark variant.

The `vsphere/2` icon set is already live, so there is no rollout dependency.
