### PR TITLE
build: Remove build steps from Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
     - architect/go-build:
         context: architect
         name: go-build
-        binary: cluster-api-cleaner-vsphere
+        binary: manager
         resource_class: xlarge
         filters:
           tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove superfluous build steps from the Dockerfile.
+- Add a Dockerfile for local development and testing.
+
 ## [0.5.2] - 2026-06-15
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,11 @@
-# Build the manager binary
-FROM docker.io/golang:1.26 as builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-#COPY api/ api/
-COPY controllers/ controllers/
-COPY pkg/ pkg/
-
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
+
+ARG TARGETOS
+ARG TARGETARCH
+COPY manager-${TARGETOS}-${TARGETARCH} /manager
+
 USER nonroot:nonroot
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,30 @@
+# This Dockerfile can be used to build a local image for testing purposes. It is not used by CI to build images which are pushed to a registry.
+
+# Build the manager binary
+FROM docker.io/golang:1.26 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+#COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## What does this PR do?

- Removes the build steps from the Dockerfile as these are already executed in the go-build step in the CircleCI workflow.

## Checklist

- [x] Update changelog in CHANGELOG.md.
