### PR TITLE
test: add integration tests for the controller and the volume cleaner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add integration tests for the controller and the volume cleaner. Run them with `make integration-test`.
+
 ### Changed
 
 - fix(deps): update module github.com/go-logr/logr to v1.4.4

--- a/Makefile.integration.mk
+++ b/Makefile.integration.mk
@@ -1,0 +1,26 @@
+
+# Integration tests. These run locally only: CI runs "go test ./..." without a
+# build tag, which skips them.
+#
+# This file is included automatically by the "include Makefile.*.mk" line in the
+# root Makefile. The glob is alphabetical, so this file is read before
+# Makefile.kubebuilder.mk. It therefore defines its own bin directory instead of
+# relying on the GOBIN that file sets up later.
+
+##@ Integration tests
+
+INTEGRATION_GOBIN := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
+
+# Matches k8s.io/api v0.36.x. Run "setup-envtest list" to see what is available.
+ENVTEST_K8S_VERSION ?= 1.36.x
+ENVTEST_VERSION ?= release-0.24
+ENVTEST ?= $(INTEGRATION_GOBIN)/setup-envtest
+
+.PHONY: setup-envtest
+setup-envtest: ## Download setup-envtest locally if necessary.
+	test -s $(ENVTEST) || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
+
+.PHONY: integration-test
+integration-test: setup-envtest ## Run the integration tests against envtest and a vCenter simulator.
+	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
+		go test -tags integration ./... -count=1

--- a/Makefile.integration.mk
+++ b/Makefile.integration.mk
@@ -23,4 +23,4 @@ setup-envtest: ## Download setup-envtest locally if necessary.
 .PHONY: integration-test
 integration-test: setup-envtest ## Run the integration tests against envtest and a vCenter simulator.
 	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
-		go test -tags integration ./... -count=1
+		go test -v -tags integration ./... -count=1

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,0 +1,391 @@
+//go:build integration
+
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	capv "sigs.k8s.io/cluster-api-provider-vsphere/api/govmomi/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/identity"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+
+	"github.com/giantswarm/cluster-api-cleaner-vsphere/internal/vcsim"
+	"github.com/giantswarm/cluster-api-cleaner-vsphere/pkg/cleaner"
+	"github.com/giantswarm/cluster-api-cleaner-vsphere/pkg/key"
+)
+
+// testClusterName is the name shared by the Cluster and the VSphereCluster in
+// every test. The cleaner scopes its work by cluster name, so the two must match.
+const testClusterName = "test-cluster"
+
+// k8sClient talks to the envtest apiserver. It is shared by every test in the
+// package, so tests isolate themselves with a namespace each.
+var k8sClient client.Client
+
+// namespaceCounter names namespaces uniquely within a run.
+var namespaceCounter atomic.Int64
+
+func TestMain(m *testing.M) {
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) int {
+	paths, err := crdPaths()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	testEnv := &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{Paths: paths},
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start envtest: %s\n"+
+			"Run the suite with 'make integration-test', which sets KUBEBUILDER_ASSETS.\n", err)
+		return 1
+	}
+
+	defer func() {
+		if err := testEnv.Stop(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to stop envtest: %s\n", err)
+		}
+	}()
+
+	scheme := runtime.NewScheme()
+	for _, addToScheme := range []func(*runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		capi.AddToScheme,
+		capv.AddToScheme,
+	} {
+		if err := addToScheme(scheme); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to build scheme: %s\n", err)
+			return 1
+		}
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create client: %s\n", err)
+		return 1
+	}
+
+	return m.Run()
+}
+
+// crdPaths locates the CAPI and CAPV CRDs in the module cache. The operator
+// defines no API types of its own, so it ships no CRDs to install.
+func crdPaths() ([]string, error) {
+	modules := []struct {
+		path string
+		crd  string
+	}{
+		{"sigs.k8s.io/cluster-api", "config/crd/bases/cluster.x-k8s.io_clusters.yaml"},
+		// Note the extra "default" segment, which CAPI does not have.
+		{"sigs.k8s.io/cluster-api-provider-vsphere", "config/default/crd/bases/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml"},
+	}
+
+	paths := make([]string, 0, len(modules))
+	for _, module := range modules {
+		// The module path is a constant from the slice above, not user input.
+		out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", module.path).Output() //nolint:gosec
+		if err != nil {
+			return nil, fmt.Errorf("failed to locate module %s: %w", module.path, err)
+		}
+
+		dir := strings.TrimSpace(string(out))
+		if dir == "" {
+			return nil, fmt.Errorf("module %s is not in the module cache, run 'go mod download'", module.path)
+		}
+
+		paths = append(paths, filepath.Join(dir, module.crd))
+	}
+
+	return paths, nil
+}
+
+// newNamespace creates a namespace for a single test.
+//
+// envtest runs no namespace controller, so namespaces are never deleted. Every
+// test gets a fresh one instead of cleaning up after itself.
+func newNamespace(ctx context.Context, t *testing.T) string {
+	t.Helper()
+
+	name := fmt.Sprintf("test-%d", namespaceCounter.Add(1))
+	namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	require.NoError(t, k8sClient.Create(ctx, namespace))
+
+	return name
+}
+
+// newCluster creates the owner Cluster that the reconciler looks up.
+//
+// Paused is always set, even when false. ClusterSpec is tagged omitzero and the
+// CRD requires spec, so a fully zero spec is dropped from the request body and
+// the apiserver rejects the object.
+func newCluster(ctx context.Context, t *testing.T, namespace, name string, paused bool) *capi.Cluster {
+	t.Helper()
+
+	cluster := &capi.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       capi.ClusterSpec{Paused: ptr.To(paused)},
+	}
+	require.NoError(t, k8sClient.Create(ctx, cluster))
+
+	return cluster
+}
+
+// newIdentitySecret creates a vCenter credentials secret. identity.GetCredentials
+// reads Data, not StringData.
+func newIdentitySecret(ctx context.Context, t *testing.T, namespace, name, username, password string) *v1.Secret {
+	t.Helper()
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data: map[string][]byte{
+			identity.UsernameKey: []byte(username),
+			identity.PasswordKey: []byte(password),
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, secret))
+
+	return secret
+}
+
+// vsphereClusterConfig describes a VSphereCluster to create.
+type vsphereClusterConfig struct {
+	namespace string
+	name      string
+
+	// owner is the Cluster to reference. A nil owner leaves the ownerRef unset,
+	// which is what the reconciler treats as "not yet set".
+	owner *capi.Cluster
+
+	// clusterName sets the CAPI cluster-name label. An empty value omits the
+	// label, which the delete path requires.
+	clusterName string
+
+	// identityRef is optional. The CRD requires both kind and name when present.
+	identityRef *capv.VSphereIdentityReference
+
+	// server defaults to a dummy address for tests that never reach vCenter.
+	// The CRD requires it.
+	server string
+
+	finalizers  []string
+	annotations map[string]string
+}
+
+func createVSphereCluster(ctx context.Context, t *testing.T, config vsphereClusterConfig) *capv.VSphereCluster {
+	t.Helper()
+
+	if config.server == "" {
+		config.server = "vcenter.example.com"
+	}
+
+	vsphereCluster := &capv.VSphereCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        config.name,
+			Namespace:   config.namespace,
+			Finalizers:  config.finalizers,
+			Annotations: config.annotations,
+		},
+		Spec: capv.VSphereClusterSpec{Server: config.server},
+	}
+
+	if config.clusterName != "" {
+		vsphereCluster.Labels = map[string]string{key.CapiClusterLabelKey: config.clusterName}
+	}
+
+	if config.identityRef != nil {
+		vsphereCluster.Spec.IdentityRef = *config.identityRef
+	}
+
+	if config.owner != nil {
+		vsphereCluster.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: capi.GroupVersion.String(),
+			Kind:       "Cluster",
+			Name:       config.owner.Name,
+			UID:        config.owner.UID,
+		}}
+	}
+
+	require.NoError(t, k8sClient.Create(ctx, vsphereCluster))
+
+	return vsphereCluster
+}
+
+// secretIdentityRef builds an IdentityRef of kind Secret.
+func secretIdentityRef(name string) *capv.VSphereIdentityReference {
+	return &capv.VSphereIdentityReference{Kind: capv.SecretKind, Name: name}
+}
+
+func newReconciler(t *testing.T, cleaners ...cleaner.Cleaner) *VSphereClusterReconciler {
+	t.Helper()
+
+	return &VSphereClusterReconciler{
+		Client:   k8sClient,
+		Log:      testr.New(t),
+		Cleaners: cleaners,
+	}
+}
+
+// callReconcile calls Reconcile directly rather than starting a manager. That
+// keeps results and cleaner call counts exactly assertable, with no polling.
+//
+// It is not named reconcile, because the package under test already imports a
+// package by that name.
+func callReconcile(ctx context.Context, r *VSphereClusterReconciler, obj client.Object) (ctrl.Result, error) {
+	return r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(obj)})
+}
+
+// getVSphereCluster re-reads a VSphereCluster. It returns nil when the object is
+// gone, which is how the tests assert that the last finalizer was removed.
+func getVSphereCluster(ctx context.Context, t *testing.T, obj client.Object) *capv.VSphereCluster {
+	t.Helper()
+
+	vsphereCluster := &capv.VSphereCluster{}
+	err := k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), vsphereCluster)
+	if err != nil {
+		require.True(t, apierrors.IsNotFound(err), "unexpected error reading VSphereCluster: %s", err)
+		return nil
+	}
+
+	return vsphereCluster
+}
+
+// getSecret re-reads a secret, returning nil when it is gone.
+func getSecret(ctx context.Context, t *testing.T, obj client.Object) *v1.Secret {
+	t.Helper()
+
+	secret := &v1.Secret{}
+	err := k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), secret)
+	if err != nil {
+		require.True(t, apierrors.IsNotFound(err), "unexpected error reading secret: %s", err)
+		return nil
+	}
+
+	return secret
+}
+
+// hasCleanerFinalizer reports whether the object carries the operator finalizer.
+func hasCleanerFinalizer(obj client.Object) bool {
+	return controllerutil.ContainsFinalizer(obj, key.CleanerFinalizerName)
+}
+
+// newSimulator starts a vCenter simulator scoped to one test.
+func newSimulator(t *testing.T) *vcsim.Simulator {
+	t.Helper()
+
+	simulator, err := vcsim.New()
+	require.NoError(t, err)
+	t.Cleanup(simulator.Close)
+
+	return simulator
+}
+
+// deletingCluster is a VSphereCluster part way through deletion: the finalizers
+// are installed, the deletion timestamp is set, and Spec.Server points at a live
+// simulator so the real getVCenterSession succeeds.
+type deletingCluster struct {
+	reconciler     *VSphereClusterReconciler
+	vsphereCluster *capv.VSphereCluster
+	secret         *v1.Secret
+	simulator      *vcsim.Simulator
+}
+
+func newDeletingCluster(ctx context.Context, t *testing.T, cleaners ...cleaner.Cleaner) *deletingCluster {
+	t.Helper()
+
+	simulator := newSimulator(t)
+	namespace := newNamespace(ctx, t)
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+	secret := newIdentitySecret(ctx, t, namespace, "credentials", simulator.Username(), simulator.Password())
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace:   namespace,
+		name:        testClusterName,
+		owner:       owner,
+		clusterName: testClusterName,
+		identityRef: secretIdentityRef(secret.Name),
+		server:      simulator.Host(),
+	})
+
+	reconciler := newReconciler(t, cleaners...)
+
+	// Reconcile once to install the finalizers, then start the deletion.
+	_, err := callReconcile(ctx, reconciler, vsphereCluster)
+	require.NoError(t, err)
+	require.NoError(t, k8sClient.Delete(ctx, vsphereCluster))
+
+	return &deletingCluster{
+		reconciler:     reconciler,
+		vsphereCluster: vsphereCluster,
+		secret:         secret,
+		simulator:      simulator,
+	}
+}
+
+// stubCleaner stands in for a real cleaner, recording its calls.
+type stubCleaner struct {
+	calls   int
+	requeue bool
+	err     error
+
+	// onClean runs before the configured result is returned, letting a test
+	// mutate the cluster mid-cleanup.
+	onClean func(ctx context.Context) error
+}
+
+var _ cleaner.Cleaner = &stubCleaner{}
+
+func (c *stubCleaner) Clean(ctx context.Context, _ logr.Logger, _ *session.Session, _ *capv.VSphereCluster) (bool, error) {
+	c.calls++
+
+	if c.onClean != nil {
+		if err := c.onClean(ctx); err != nil {
+			return false, err
+		}
+	}
+
+	return c.requeue, c.err
+}

--- a/controllers/vspherecluster_controller_test.go
+++ b/controllers/vspherecluster_controller_test.go
@@ -1,0 +1,526 @@
+//go:build integration
+
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	capv "sigs.k8s.io/cluster-api-provider-vsphere/api/govmomi/v1beta2"
+
+	"github.com/giantswarm/cluster-api-cleaner-vsphere/pkg/cleaner"
+	"github.com/giantswarm/cluster-api-cleaner-vsphere/pkg/key"
+)
+
+// TestReconcileMissingVSphereCluster covers a request for an object that is gone.
+func TestReconcileMissingVSphereCluster(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	request := ctrl.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: "does-not-exist"}}
+
+	result, err := newReconciler(t).Reconcile(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+}
+
+// TestReconcileSkipsFinalizer covers the guards that must run before the operator
+// takes ownership of a cluster.
+func TestReconcileSkipsFinalizer(t *testing.T) {
+	tests := []struct {
+		name        string
+		withOwner   bool
+		paused      bool
+		annotations map[string]string
+	}{
+		{
+			name:      "owner reference is not set yet",
+			withOwner: false,
+		},
+		{
+			name:      "owner cluster is paused",
+			withOwner: true,
+			paused:    true,
+		},
+		{
+			name:        "infrastructure cluster has the paused annotation",
+			withOwner:   true,
+			annotations: map[string]string{capi.PausedAnnotation: ""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			namespace := newNamespace(ctx, t)
+
+			config := vsphereClusterConfig{
+				namespace:   namespace,
+				name:        testClusterName,
+				clusterName: testClusterName,
+				annotations: tc.annotations,
+			}
+			if tc.withOwner {
+				config.owner = newCluster(ctx, t, namespace, testClusterName, tc.paused)
+			}
+
+			vsphereCluster := createVSphereCluster(ctx, t, config)
+
+			result, err := callReconcile(ctx, newReconciler(t), vsphereCluster)
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result)
+
+			require.False(t, hasCleanerFinalizer(getVSphereCluster(ctx, t, vsphereCluster)),
+				"the finalizer must not be added")
+		})
+	}
+}
+
+// TestReconcileNormalAddsFinalizer covers a cluster with no identity reference.
+// An unrelated secret proves the reconciler does not touch secrets it was not
+// pointed at.
+func TestReconcileNormalAddsFinalizer(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+	unrelated := newIdentitySecret(ctx, t, namespace, "unrelated", "user", "pass")
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace:   namespace,
+		name:        testClusterName,
+		owner:       owner,
+		clusterName: testClusterName,
+	})
+
+	result, err := callReconcile(ctx, newReconciler(t), vsphereCluster)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	require.True(t, hasCleanerFinalizer(getVSphereCluster(ctx, t, vsphereCluster)))
+	require.False(t, hasCleanerFinalizer(getSecret(ctx, t, unrelated)),
+		"an unreferenced secret must not get a finalizer")
+}
+
+// TestReconcileNormalAddsFinalizerToIdentitySecret covers credential protection.
+// The secret must survive until the clean-up is done.
+func TestReconcileNormalAddsFinalizerToIdentitySecret(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+	secret := newIdentitySecret(ctx, t, namespace, "credentials", "user", "pass")
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace:   namespace,
+		name:        testClusterName,
+		owner:       owner,
+		clusterName: testClusterName,
+		identityRef: secretIdentityRef(secret.Name),
+	})
+
+	_, err := callReconcile(ctx, newReconciler(t), vsphereCluster)
+	require.NoError(t, err)
+
+	require.True(t, hasCleanerFinalizer(getVSphereCluster(ctx, t, vsphereCluster)))
+	require.True(t, hasCleanerFinalizer(getSecret(ctx, t, secret)))
+}
+
+// TestReconcileNormalIsIdempotent covers repeated reconciles, which the manager
+// does routinely.
+func TestReconcileNormalIsIdempotent(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+	secret := newIdentitySecret(ctx, t, namespace, "credentials", "user", "pass")
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace:   namespace,
+		name:        testClusterName,
+		owner:       owner,
+		clusterName: testClusterName,
+		identityRef: secretIdentityRef(secret.Name),
+	})
+
+	reconciler := newReconciler(t)
+	for i := range 3 {
+		_, err := callReconcile(ctx, reconciler, vsphereCluster)
+		require.NoError(t, err, "reconcile %d failed", i+1)
+	}
+
+	require.Equal(t, []string{key.CleanerFinalizerName},
+		getVSphereCluster(ctx, t, vsphereCluster).Finalizers)
+	require.Equal(t, []string{key.CleanerFinalizerName},
+		getSecret(ctx, t, secret).Finalizers)
+}
+
+// TestReconcileNormalMissingIdentitySecret pins an asymmetry: the normal path
+// fails on a missing secret, while the delete path tolerates it.
+func TestReconcileNormalMissingIdentitySecret(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace:   namespace,
+		name:        testClusterName,
+		owner:       owner,
+		clusterName: testClusterName,
+		identityRef: secretIdentityRef("does-not-exist"),
+	})
+
+	_, err := callReconcile(ctx, newReconciler(t), vsphereCluster)
+	require.Error(t, err)
+
+	// The finalizer still lands on the cluster, because it is added first.
+	require.True(t, hasCleanerFinalizer(getVSphereCluster(ctx, t, vsphereCluster)))
+}
+
+// TestReconcileNormalClusterIdentityKind pins that a VSphereClusterIdentity
+// reference gets no finalizer protection, because IsSecretIdentity is false. The
+// secret behind such an identity is therefore deletable mid-cleanup.
+func TestReconcileNormalClusterIdentityKind(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+	secret := newIdentitySecret(ctx, t, namespace, "credentials", "user", "pass")
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace:   namespace,
+		name:        testClusterName,
+		owner:       owner,
+		clusterName: testClusterName,
+		identityRef: &capv.VSphereIdentityReference{
+			Kind: capv.VSphereClusterIdentityKind,
+			Name: "cluster-identity",
+		},
+	})
+
+	_, err := callReconcile(ctx, newReconciler(t), vsphereCluster)
+	require.NoError(t, err)
+
+	require.True(t, hasCleanerFinalizer(getVSphereCluster(ctx, t, vsphereCluster)))
+	require.False(t, hasCleanerFinalizer(getSecret(ctx, t, secret)),
+		"a VSphereClusterIdentity secret gets no finalizer")
+}
+
+// TestReconcileDeleteWithoutCleanerFinalizer covers a deleting cluster the
+// operator never took ownership of.
+func TestReconcileDeleteWithoutCleanerFinalizer(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+
+	// A foreign finalizer keeps the object observable while it deletes. With no
+	// finalizer at all the apiserver removes it immediately, so this branch would
+	// be unreachable.
+	const foreignFinalizer = "example.com/hold"
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace:   namespace,
+		name:        testClusterName,
+		owner:       owner,
+		clusterName: testClusterName,
+		finalizers:  []string{foreignFinalizer},
+	})
+	require.NoError(t, k8sClient.Delete(ctx, vsphereCluster))
+
+	stub := &stubCleaner{}
+
+	result, err := callReconcile(ctx, newReconciler(t, stub), vsphereCluster)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	require.Zero(t, stub.calls, "the cleaner must not run")
+
+	current := getVSphereCluster(ctx, t, vsphereCluster)
+	require.NotNil(t, current)
+	require.Equal(t, []string{foreignFinalizer}, current.Finalizers,
+		"a foreign finalizer must be left alone")
+}
+
+// TestReconcileDeleteWithoutClusterNameLabel pins a latent bug.
+//
+// BUG: the delete path returns early when the CAPI cluster-name label is
+// missing, without removing the finalizer. The object then blocks its own
+// deletion forever, and nothing in the normal path guarantees the label exists.
+func TestReconcileDeleteWithoutClusterNameLabel(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace: namespace,
+		name:      testClusterName,
+		owner:     owner,
+		// No clusterName, so the label is absent.
+		finalizers: []string{key.CleanerFinalizerName},
+	})
+	require.NoError(t, k8sClient.Delete(ctx, vsphereCluster))
+
+	stub := &stubCleaner{}
+
+	result, err := callReconcile(ctx, newReconciler(t, stub), vsphereCluster)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	require.Zero(t, stub.calls, "the cleaner must not run")
+
+	current := getVSphereCluster(ctx, t, vsphereCluster)
+	require.NotNil(t, current, "the object is stuck, so it must still exist")
+	require.True(t, hasCleanerFinalizer(current),
+		"BUG: the finalizer stays, so the cluster never finishes deleting")
+}
+
+// TestReconcileDeleteRemovesFinalizers covers the happy path end to end.
+func TestReconcileDeleteRemovesFinalizers(t *testing.T) {
+	ctx := t.Context()
+
+	first, second := &stubCleaner{}, &stubCleaner{}
+	fixture := newDeletingCluster(ctx, t, first, second)
+
+	result, err := callReconcile(ctx, fixture.reconciler, fixture.vsphereCluster)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	require.Equal(t, 1, first.calls)
+	require.Equal(t, 1, second.calls, "every cleaner must run")
+
+	require.Nil(t, getVSphereCluster(ctx, t, fixture.vsphereCluster),
+		"the last finalizer is gone, so the apiserver removed the object")
+
+	secret := getSecret(ctx, t, fixture.secret)
+	require.NotNil(t, secret)
+	require.False(t, hasCleanerFinalizer(secret), "the secret must be released")
+}
+
+// TestReconcileDeleteWithMissingIdentitySecret covers a cluster whose credentials
+// are already gone. Deletion must still finish rather than block on a vCenter it
+// cannot reach.
+func TestReconcileDeleteWithMissingIdentitySecret(t *testing.T) {
+	ctx := t.Context()
+	namespace := newNamespace(ctx, t)
+
+	owner := newCluster(ctx, t, namespace, testClusterName, false)
+
+	vsphereCluster := createVSphereCluster(ctx, t, vsphereClusterConfig{
+		namespace:   namespace,
+		name:        testClusterName,
+		owner:       owner,
+		clusterName: testClusterName,
+		identityRef: secretIdentityRef("does-not-exist"),
+		finalizers:  []string{key.CleanerFinalizerName},
+	})
+	require.NoError(t, k8sClient.Delete(ctx, vsphereCluster))
+
+	stub := &stubCleaner{}
+
+	result, err := callReconcile(ctx, newReconciler(t, stub), vsphereCluster)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	require.Zero(t, stub.calls, "clean-up is skipped when the credentials are gone")
+
+	require.Nil(t, getVSphereCluster(ctx, t, vsphereCluster))
+}
+
+// TestReconcileDeleteCleanerError covers a failing cleaner. The finalizers must
+// survive, so the clean-up is retried instead of leaking resources.
+func TestReconcileDeleteCleanerError(t *testing.T) {
+	ctx := t.Context()
+
+	stub := &stubCleaner{err: errors.New("clean-up failed")}
+	fixture := newDeletingCluster(ctx, t, stub)
+
+	_, err := callReconcile(ctx, fixture.reconciler, fixture.vsphereCluster)
+	require.Error(t, err)
+	require.Equal(t, 1, stub.calls)
+
+	current := getVSphereCluster(ctx, t, fixture.vsphereCluster)
+	require.NotNil(t, current)
+	require.True(t, hasCleanerFinalizer(current), "the finalizer must survive a failure")
+	require.True(t, hasCleanerFinalizer(getSecret(ctx, t, fixture.secret)),
+		"the credentials must stay protected for the retry")
+}
+
+// TestReconcileDeleteRequeue covers a cleaner reporting unfinished work.
+func TestReconcileDeleteRequeue(t *testing.T) {
+	ctx := t.Context()
+
+	done, pending := &stubCleaner{}, &stubCleaner{requeue: true}
+	fixture := newDeletingCluster(ctx, t, done, pending)
+
+	result, err := callReconcile(ctx, fixture.reconciler, fixture.vsphereCluster)
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Second, result.RequeueAfter)
+
+	require.Equal(t, 1, done.calls)
+	require.Equal(t, 1, pending.calls, "one requeue must not stop the other cleaners")
+
+	current := getVSphereCluster(ctx, t, fixture.vsphereCluster)
+	require.NotNil(t, current)
+	require.True(t, hasCleanerFinalizer(current), "the finalizer must survive a requeue")
+}
+
+// TestReconcileDeleteStopsAtFirstError covers the loop aborting. Cleaners after a
+// failing one do not run, so their work waits for the retry.
+func TestReconcileDeleteStopsAtFirstError(t *testing.T) {
+	ctx := t.Context()
+
+	failing := &stubCleaner{err: errors.New("clean-up failed")}
+	later := &stubCleaner{}
+	fixture := newDeletingCluster(ctx, t, failing, later)
+
+	_, err := callReconcile(ctx, fixture.reconciler, fixture.vsphereCluster)
+	require.Error(t, err)
+
+	require.Equal(t, 1, failing.calls)
+	require.Zero(t, later.calls, "the loop must stop at the first error")
+}
+
+// TestReconcileDeleteToleratesSecretRemovedDuringCleanup covers the secret
+// disappearing between the clean-up and the finalizer removal.
+func TestReconcileDeleteToleratesSecretRemovedDuringCleanup(t *testing.T) {
+	ctx := t.Context()
+
+	stub := &stubCleaner{}
+	fixture := newDeletingCluster(ctx, t, stub)
+
+	// Delete the secret from inside the clean-up, which is the race the delete
+	// path guards against.
+	stub.onClean = func(ctx context.Context) error {
+		secret := getSecret(ctx, t, fixture.secret)
+		if secret == nil {
+			return nil
+		}
+
+		secret.SetFinalizers(nil)
+		if err := k8sClient.Update(ctx, secret); err != nil {
+			return err
+		}
+
+		return k8sClient.Delete(ctx, secret)
+	}
+
+	result, err := callReconcile(ctx, fixture.reconciler, fixture.vsphereCluster)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+	require.Equal(t, 1, stub.calls)
+
+	require.Nil(t, getSecret(ctx, t, fixture.secret))
+	require.Nil(t, getVSphereCluster(ctx, t, fixture.vsphereCluster))
+}
+
+// TestReconcileDeleteReleasesSecretFirst covers the finalizer removal order. If
+// the cluster were released first, a crash in between would leave the secret
+// undeletable with nothing left to clean it up.
+func TestReconcileDeleteReleasesSecretFirst(t *testing.T) {
+	ctx := t.Context()
+
+	fixture := newDeletingCluster(ctx, t, &stubCleaner{})
+
+	recorder := &updateRecorder{Client: k8sClient}
+	fixture.reconciler.Client = recorder
+
+	_, err := callReconcile(ctx, fixture.reconciler, fixture.vsphereCluster)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"secret", "vspherecluster"}, recorder.updates)
+}
+
+// TestReconcileDeleteUnreachableVCenter pins a latent bug.
+//
+// BUG: when vCenter cannot be reached the error propagates and the finalizers
+// stay, so a cluster whose vCenter is permanently gone can never be deleted
+// without manual intervention.
+func TestReconcileDeleteUnreachableVCenter(t *testing.T) {
+	ctx := t.Context()
+
+	stub := &stubCleaner{}
+	fixture := newDeletingCluster(ctx, t, stub)
+
+	// Closing the simulator makes the vCenter address refuse connections.
+	fixture.simulator.Close()
+
+	_, err := callReconcile(ctx, fixture.reconciler, fixture.vsphereCluster)
+	require.Error(t, err)
+	require.Zero(t, stub.calls, "no cleaner runs without a session")
+
+	current := getVSphereCluster(ctx, t, fixture.vsphereCluster)
+	require.NotNil(t, current)
+	require.True(t, hasCleanerFinalizer(current),
+		"BUG: the cluster cannot finish deleting while vCenter is unreachable")
+}
+
+// TestReconcileDeleteDeletesVolumes covers the whole operator against a
+// simulator: the real volume cleaner, a real vCenter session, and a real
+// apiserver. It also proves the clean-up is scoped to one cluster.
+func TestReconcileDeleteDeletesVolumes(t *testing.T) {
+	ctx := t.Context()
+
+	fixture := newDeletingCluster(ctx, t, cleaner.NewVolumeCleaner(k8sClient))
+
+	_, err := fixture.simulator.SeedVolume(ctx, fixture.vsphereCluster.Name, "pvc-owned")
+	require.NoError(t, err)
+
+	_, err = fixture.simulator.SeedVolume(ctx, "other-cluster", "pvc-other")
+	require.NoError(t, err)
+
+	result, err := callReconcile(ctx, fixture.reconciler, fixture.vsphereCluster)
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	require.Nil(t, getVSphereCluster(ctx, t, fixture.vsphereCluster))
+
+	remaining, err := fixture.simulator.VolumeNames(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"pvc-other"}, remaining,
+		"only the deleted cluster's volume may be removed")
+}
+
+// updateRecorder records the kind of each updated object, in order.
+type updateRecorder struct {
+	client.Client
+
+	updates []string
+}
+
+func (c *updateRecorder) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	switch obj.(type) {
+	case *v1.Secret:
+		c.updates = append(c.updates, "secret")
+	case *capv.VSphereCluster:
+		c.updates = append(c.updates, "vspherecluster")
+	default:
+		c.updates = append(c.updates, fmt.Sprintf("%T", obj))
+	}
+
+	return c.Client.Update(ctx, obj, opts...)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.26.0
 require (
 	github.com/giantswarm/microerror v0.4.1
 	github.com/go-logr/logr v1.4.4
+	github.com/stretchr/testify v1.11.1
 	github.com/vmware/govmomi v0.55.1
 	go.uber.org/zap v1.28.0
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/cluster-api v1.13.4
 	sigs.k8s.io/cluster-api-provider-vsphere v1.16.1
 	sigs.k8s.io/controller-runtime v0.24.1
@@ -63,7 +65,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect

--- a/internal/vcsim/vcsim.go
+++ b/internal/vcsim/vcsim.go
@@ -1,0 +1,228 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vcsim starts an in-process vCenter simulator for tests. It registers
+// the CNS endpoint, so tests can seed and query container volumes.
+//
+// This package is not build-tagged. A package whose every file is excluded by a
+// build constraint breaks "go test ./...", which CI runs. Nothing in the shipped
+// binary imports it.
+package vcsim
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"sync"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/cns"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vslm"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+
+	_ "github.com/vmware/govmomi/cns/simulator"  // registers the CNS endpoint
+	_ "github.com/vmware/govmomi/vapi/simulator" // registers the vAPI endpoints, needed by session.GetOrCreate
+)
+
+// Simulator is a running vCenter simulator.
+type Simulator struct {
+	model  *simulator.Model
+	server *simulator.Server
+	close  sync.Once
+}
+
+// New starts a simulator. The caller must call Close.
+//
+// Use one Simulator per test. Each instance binds a random port, and
+// session.GetOrCreate keys its process-global cache on the server address, so a
+// fresh port is what keeps tests isolated from each other.
+func New() (*Simulator, error) {
+	// The CNS and vAPI endpoints only register against a VPX model.
+	model := simulator.VPX()
+
+	if err := model.Create(); err != nil {
+		return nil, fmt.Errorf("failed to create simulator model: %w", err)
+	}
+
+	// session.GetOrCreate builds an https URL, so TLS is mandatory. httptest
+	// supplies a default certificate when Certificates is empty.
+	model.Service.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
+
+	// Invokes the endpoints registered by the blank imports above.
+	model.Service.RegisterEndpoints = true
+
+	return &Simulator{model: model, server: model.Service.NewServer()}, nil
+}
+
+// Close shuts the simulator down and removes its temporary files. It is safe to
+// call more than once, so a test can close the simulator early to make vCenter
+// unreachable and still leave its cleanup registered.
+func (s *Simulator) Close() {
+	s.close.Do(func() {
+		s.server.Close()
+		s.model.Remove()
+	})
+}
+
+// Host returns the "host:port" address to put in VSphereCluster.Spec.Server.
+func (s *Simulator) Host() string {
+	return s.server.URL.Host
+}
+
+// Username returns the username the simulator accepts.
+func (s *Simulator) Username() string {
+	return simulator.DefaultLogin.Username()
+}
+
+// Password returns the password the simulator accepts.
+func (s *Simulator) Password() string {
+	password, _ := simulator.DefaultLogin.Password()
+	return password
+}
+
+// Session returns a session pointing at the simulator.
+//
+// It builds the Session directly rather than calling session.GetOrCreate, so it
+// neither needs a datacenter nor writes to that function's global cache.
+func (s *Simulator) Session(ctx context.Context) (*session.Session, error) {
+	client, err := govmomi.NewClient(ctx, s.server.URL, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create govmomi client: %w", err)
+	}
+
+	return &session.Session{Client: client}, nil
+}
+
+// SeedVolume creates a CNS container volume owned by clusterID and returns its
+// volume ID. The cleaner finds volumes by matching clusterID, so this is what
+// makes a volume visible to it.
+func (s *Simulator) SeedVolume(ctx context.Context, clusterID, name string) (string, error) {
+	client, err := s.cnsClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	datastore := s.model.Map().Any("Datastore").(*simulator.Datastore)
+
+	spec := cnstypes.CnsVolumeCreateSpec{
+		Name:       name,
+		VolumeType: string(cnstypes.CnsVolumeTypeBlock),
+		Datastores: []types.ManagedObjectReference{datastore.Self},
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster: cnstypes.CnsContainerCluster{
+				ClusterType:   string(cnstypes.CnsClusterTypeKubernetes),
+				ClusterId:     clusterID,
+				ClusterFlavor: string(cnstypes.CnsClusterFlavorVanilla),
+				VSphereUser:   s.Username(),
+			},
+		},
+		BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
+			CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{CapacityInMb: 1024},
+		},
+	}
+
+	task, err := client.CreateVolume(ctx, []cnstypes.CnsVolumeCreateSpec{spec})
+	if err != nil {
+		return "", fmt.Errorf("failed to start volume creation: %w", err)
+	}
+
+	info, err := task.WaitForResultEx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create volume: %w", err)
+	}
+
+	result, ok := info.Result.(cnstypes.CnsVolumeOperationBatchResult)
+	if !ok {
+		return "", fmt.Errorf("unexpected create result type %T", info.Result)
+	}
+
+	if len(result.VolumeResults) != 1 {
+		return "", fmt.Errorf("expected 1 volume result, got %d", len(result.VolumeResults))
+	}
+
+	operationResult := result.VolumeResults[0].GetCnsVolumeOperationResult()
+	if operationResult.Fault != nil {
+		return "", fmt.Errorf("failed to create volume: %s", operationResult.Fault.LocalizedMessage)
+	}
+
+	return operationResult.VolumeId.Id, nil
+}
+
+// VolumeNames returns the names of the volumes owned by clusterID. An empty
+// clusterID returns every volume.
+func (s *Simulator) VolumeNames(ctx context.Context, clusterID string) ([]string, error) {
+	client, err := s.cnsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := cnstypes.CnsQueryFilter{}
+	if clusterID != "" {
+		filter.ContainerClusterIds = []string{clusterID}
+	}
+
+	result, err := client.QueryVolume(ctx, &filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query volumes: %w", err)
+	}
+
+	names := make([]string, 0, len(result.Volumes))
+	for _, volume := range result.Volumes {
+		names = append(names, volume.Name)
+	}
+
+	return names, nil
+}
+
+// DeleteBackingDisk removes the first class disk behind a volume, leaving the
+// CNS volume record in place. A later delete of that volume then reports a fault
+// in its batch result, which is otherwise unreachable.
+func (s *Simulator) DeleteBackingDisk(ctx context.Context, volumeID string) error {
+	client, err := govmomi.NewClient(ctx, s.server.URL, true)
+	if err != nil {
+		return fmt.Errorf("failed to create govmomi client: %w", err)
+	}
+
+	datastore := s.model.Map().Any("Datastore").(*simulator.Datastore)
+
+	task, err := vslm.NewObjectManager(client.Client).Delete(ctx, datastore, volumeID)
+	if err != nil {
+		return fmt.Errorf("failed to start disk deletion: %w", err)
+	}
+
+	if err := task.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to delete disk: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Simulator) cnsClient(ctx context.Context) (*cns.Client, error) {
+	client, err := govmomi.NewClient(ctx, s.server.URL, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create govmomi client: %w", err)
+	}
+
+	cnsClient, err := cns.NewClient(ctx, client.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CNS client: %w", err)
+	}
+
+	return cnsClient, nil
+}

--- a/pkg/cleaner/volumes_test.go
+++ b/pkg/cleaner/volumes_test.go
@@ -1,0 +1,161 @@
+//go:build integration
+
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleaner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	capv "sigs.k8s.io/cluster-api-provider-vsphere/api/govmomi/v1beta2"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+
+	"github.com/giantswarm/cluster-api-cleaner-vsphere/internal/vcsim"
+)
+
+// The cleaner takes a client only to satisfy its constructor. It reads nothing
+// from Kubernetes, so the tests pass a nil client.
+func newTestCleaner() *VolumeCleaner {
+	return NewVolumeCleaner(nil)
+}
+
+// newTestSimulator starts a simulator and returns it with a session pointing at
+// it. The session is built directly, so it stays out of the process-global cache
+// in session.GetOrCreate.
+func newTestSimulator(ctx context.Context, t *testing.T) (*vcsim.Simulator, *session.Session) {
+	t.Helper()
+
+	simulator, err := vcsim.New()
+	require.NoError(t, err)
+	t.Cleanup(simulator.Close)
+
+	sess, err := simulator.Session(ctx)
+	require.NoError(t, err)
+
+	return simulator, sess
+}
+
+func newVSphereCluster(name string) *capv.VSphereCluster {
+	return &capv.VSphereCluster{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+// TestCleanDeletesVolumes covers the ordinary case.
+func TestCleanDeletesVolumes(t *testing.T) {
+	ctx := t.Context()
+	simulator, sess := newTestSimulator(ctx, t)
+
+	_, err := simulator.SeedVolume(ctx, "test-cluster", "pvc-owned")
+	require.NoError(t, err)
+
+	requeue, err := newTestCleaner().Clean(ctx, testr.New(t), sess, newVSphereCluster("test-cluster"))
+	require.NoError(t, err)
+	require.False(t, requeue)
+
+	remaining, err := simulator.VolumeNames(ctx, "")
+	require.NoError(t, err)
+	require.Empty(t, remaining)
+}
+
+// TestCleanIgnoresOtherClusters is the guard against destroying another
+// cluster's data. The cleaner must only touch volumes tagged with its own
+// cluster ID.
+func TestCleanIgnoresOtherClusters(t *testing.T) {
+	ctx := t.Context()
+	simulator, sess := newTestSimulator(ctx, t)
+
+	_, err := simulator.SeedVolume(ctx, "test-cluster", "pvc-owned")
+	require.NoError(t, err)
+
+	_, err = simulator.SeedVolume(ctx, "other-cluster", "pvc-other")
+	require.NoError(t, err)
+
+	_, err = simulator.SeedVolume(ctx, "", "pvc-unowned")
+	require.NoError(t, err)
+
+	requeue, err := newTestCleaner().Clean(ctx, testr.New(t), sess, newVSphereCluster("test-cluster"))
+	require.NoError(t, err)
+	require.False(t, requeue)
+
+	remaining, err := simulator.VolumeNames(ctx, "")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"pvc-other", "pvc-unowned"}, remaining,
+		"volumes belonging to other clusters must survive")
+}
+
+// TestCleanWithoutVolumes covers a cluster that never provisioned storage.
+func TestCleanWithoutVolumes(t *testing.T) {
+	ctx := t.Context()
+	_, sess := newTestSimulator(ctx, t)
+
+	requeue, err := newTestCleaner().Clean(ctx, testr.New(t), sess, newVSphereCluster("test-cluster"))
+	require.NoError(t, err)
+	require.False(t, requeue)
+}
+
+// TestCleanDeletesEveryVolume covers a cluster with more than one volume, since
+// the cleaner deletes them one at a time.
+func TestCleanDeletesEveryVolume(t *testing.T) {
+	ctx := t.Context()
+	simulator, sess := newTestSimulator(ctx, t)
+
+	for _, name := range []string{"pvc-one", "pvc-two", "pvc-three"} {
+		_, err := simulator.SeedVolume(ctx, "test-cluster", name)
+		require.NoError(t, err)
+	}
+
+	requeue, err := newTestCleaner().Clean(ctx, testr.New(t), sess, newVSphereCluster("test-cluster"))
+	require.NoError(t, err)
+	require.False(t, requeue)
+
+	remaining, err := simulator.VolumeNames(ctx, "")
+	require.NoError(t, err)
+	require.Empty(t, remaining)
+}
+
+// TestCleanQueryError covers an unreachable vCenter.
+func TestCleanQueryError(t *testing.T) {
+	ctx := t.Context()
+	simulator, sess := newTestSimulator(ctx, t)
+
+	simulator.Close()
+
+	requeue, err := newTestCleaner().Clean(ctx, testr.New(t), sess, newVSphereCluster("test-cluster"))
+	require.Error(t, err)
+	require.False(t, requeue)
+}
+
+// TestCleanDeleteFault covers a delete that reports a fault in its batch result
+// rather than failing outright. Removing the backing disk behind a volume makes
+// the delete fail while the volume record still exists.
+func TestCleanDeleteFault(t *testing.T) {
+	ctx := t.Context()
+	simulator, sess := newTestSimulator(ctx, t)
+
+	volumeID, err := simulator.SeedVolume(ctx, "test-cluster", "pvc-owned")
+	require.NoError(t, err)
+
+	require.NoError(t, simulator.DeleteBackingDisk(ctx, volumeID))
+
+	requeue, err := newTestCleaner().Clean(ctx, testr.New(t), sess, newVSphereCluster("test-cluster"))
+	require.ErrorContains(t, err, "error while deleting volume")
+	require.False(t, requeue)
+}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/37362

This PR adds integration tests for the reconciler and the volume cleaner.

The tests run against a real API server (`envtest`) and an in-process vCenter
simulator (`vcsim`). `VSphereCluster.Spec.Server` points at the simulator, so the
real vCenter session code runs. **No production code changes.**

24 tests cover:

- **Reconcile guards** — missing object, no owner reference, paused cluster.
- **Finalizers** — added to the `VSphereCluster` and the identity secret, and idempotent.
- **Deletion** — clean-up runs, both finalizers are removed, and the object disappears.
  Also errors, requeues, a missing secret, and the finalizer removal order.
- **Volume cleaner** — deletes the cluster's CNS volumes, and leaves other clusters' volumes alone.

## How to run

```
make integration-test
```

## Latent bugs

The tests pin the current behaviour and mark it with a `// BUG:` comment. This PR
does not change any of it:

1. A missing `cluster.x-k8s.io/cluster-name` label makes the delete path return
   early without removing the finalizer. The cluster then never finishes deleting.
2. An unreachable vCenter blocks deletion indefinitely.
3. `reconcileNormal` fails on a missing identity secret, but `reconcileDelete`
   tolerates it.

One more bug has no test: two `VSphereCluster` objects that share one identity
secret also share one finalizer. Deleting either object unprotects the secret
while the other cluster is still live.

## Checklist

- [x] Update changelog in CHANGELOG.md.
